### PR TITLE
tracking PR: takes compatible options as node's createReadStream

### DIFF
--- a/examples/bench.js
+++ b/examples/bench.js
@@ -1,0 +1,60 @@
+
+var Stats = require('statistics')
+var cont = require('cont')
+
+function bench (a, b, N) {
+
+  N = N || 20,n = N
+  var results_a = [], results_b = []
+  var A, B
+
+  var wins = 0
+
+  ;(function next () {
+
+    cont.series([
+      function (cb) {
+        a(function (err, data) {
+          results_a.push(A = data)
+          cb()
+
+        })
+      },
+      function (cb) {
+        b(function (err, data) {
+          results_b.push(B = data)
+          cb()
+        })
+      }
+    ].sort(function () {
+      return Math.random() - 0.5
+    }))(function (err) {
+      if(A.time < B.time)
+        wins ++
+
+      console.log('winner:', A.time < B.time ? 'A' : 'B', A, B)
+
+      if(n-->0) next()
+      else {
+        console.log(results_a)
+        console.log(results_b)
+        console.log('chance A wins:', wins/N, wins, N - wins)
+      }
+    })
+  })()
+
+}
+
+if(!module.parent) {
+  var file = process.argv[2]
+  var pull = require('./rate')
+  var node = require('./node-rate')
+  bench(function (cb) {
+    pull(file, cb)
+  }, function (cb) {
+    node(file, cb)
+  })
+
+}
+
+

--- a/examples/bench.js
+++ b/examples/bench.js
@@ -5,6 +5,7 @@ var cont = require('cont')
 function bench (a, b, N) {
 
   N = N || 20,n = N
+  var sA = Stats(), sB = Stats()
   var results_a = [], results_b = []
   var A, B
 
@@ -15,6 +16,9 @@ function bench (a, b, N) {
     cont.series([
       function (cb) {
         a(function (err, data) {
+          var time = data.time/1000
+          var size = data.total/(1024*1024)
+          sA.value(size/time) //bytes per ms
           results_a.push(A = data)
           cb()
 
@@ -22,6 +26,9 @@ function bench (a, b, N) {
       },
       function (cb) {
         b(function (err, data) {
+          var time = data.time/1000
+          var size = data.total/(1024*1024)
+          sB.value(size/time) //bytes per ms
           results_b.push(B = data)
           cb()
         })
@@ -34,10 +41,12 @@ function bench (a, b, N) {
 
       console.log('winner:', A.time < B.time ? 'A' : 'B', A, B)
 
-      if(n-->0) next()
+      if(0<--n) next()
       else {
-        console.log(results_a)
-        console.log(results_b)
+        console.log('A: pull-stream')
+        console.log(sA.toJSON())
+        console.log('B: node stream')
+        console.log(sB.toJSON())
         console.log('chance A wins:', wins/N, wins, N - wins)
       }
     })
@@ -56,5 +65,10 @@ if(!module.parent) {
   })
 
 }
+
+
+
+
+
 
 

--- a/examples/node-rate.js
+++ b/examples/node-rate.js
@@ -1,26 +1,22 @@
-var pull = require('pull-stream')
-var File = require('../')
 
+
+var fs = require('fs')
 
 module.exports = function (file, cb) {
   var start = Date.now(), total = 0
-  pull(
-    File(file),
-    pull.drain(function (b) {
+  fs.createReadStream(file)
+    .on('data', function (b) {
       total += b.length
-    }, function (err) {
+    })
+    .on('end', function () {
       cb(null, {time: Date.now() - start, total: total})
     })
-  )
 }
-
-
 
 if(!module.parent)
   module.exports (process.argv[2], function (err, stats) {
     var seconds = stats.time/1000, mb = stats.total/(1024*1024)
     console.log(seconds, mb, mb/seconds)
   })
-
 
 

--- a/examples/rate.js
+++ b/examples/rate.js
@@ -1,0 +1,16 @@
+var pull = require('pull-stream')
+var File = require('../')
+
+var start = Date.now(), total = 0
+pull(
+  File(process.argv[2]),
+//    HighWatermark(2),
+  pull.drain(function (b) {
+    total += b.length
+  }, function (err) {
+    var mb = total/(1024*1024)
+    var elapsed = (Date.now() - start)/1000
+    console.log(mb, elapsed, mb/elapsed)
+  })
+)
+

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 'use strict';
 
 var fs = require('fs');
-
+var Decoder = require('pull-utf8-decoder')
 /**
   # pull-file
 
@@ -114,7 +114,7 @@ module.exports = function(filename, opts) {
     }
   }
 
-  return function(end, cb) {
+  function source (end, cb) {
     if (end) {
       ended = end;
       close(cb);
@@ -131,6 +131,13 @@ module.exports = function(filename, opts) {
     else
       readNext(cb);
   };
+
+  //read directly to text
+  if(opts && opts.encoding)
+    return Decoder(opts.encoding)(source)
+
+  return source
+
 };
 
 

--- a/index.js
+++ b/index.js
@@ -21,11 +21,15 @@ module.exports = function(filename, opts) {
   var bufferSize = opts && opts.bufferSize || 1024;
   var start = opts && opts.start || 0
   var end = opts && opts.end || Number.MAX_SAFE_INTEGER
-  var fd;
-  var ended;
+  var fd = opts && opts.fd
+  var ended, closeNext, busy, _cb;
+
+  var flags = opts && opts.flags || 'r'
 
   function readNext(cb) {
+    if(closeNext) return close(cb)
     var toRead = Math.min(end - start, bufferSize);
+    busy = true
     fs.read(
       fd,
       new Buffer(toRead),
@@ -33,8 +37,14 @@ module.exports = function(filename, opts) {
       toRead,
       start,
       function(err, count, buffer) {
+        busy = false
         start += count;
         // if we have received an end noticiation, just discard this data
+        if(closeNext) {
+          close(_cb)
+          return cb(closeNext)
+        }
+
         if (ended) {
           return cb(err || ended);
         }
@@ -44,43 +54,81 @@ module.exports = function(filename, opts) {
           return cb(err);
         }
 
-        cb(count === 0, count === 0 ? null : buffer.slice(0, count));
+        if(count === toRead)
+          cb(null, buffer)
+        else if(count < toRead) {
+          closeNext = true
+          cb(null, buffer.slice(0, count))
+        }
       }
     );
   }
 
   function open(cb) {
-    fs.open(filename, 'r', mode, function(err, descriptor) {
+    busy = true
+    fs.open(filename, flags, mode, function(err, descriptor) {
+      // save the file descriptor
+      fd = descriptor;
+
+      busy = false
+      if(closeNext) {
+        close(_cb)
+        return cb(closeNext)
+      }
+
       if (err) {
         return cb(err);
       }
-
-      // save the file descriptor
-      fd = descriptor;
 
       // read the next bytes
       return readNext(cb);
     });
   }
 
-  return function(end, cb) {
-    if (end) {
-      // if we have already received the end notification, abort further
-      if (ended) {
-        return cb(ended)
-      }
+  function close (cb) {
+    //if auto close is disabled, then user manages fd.
+    if(opts && opts.autoClose === false) return cb(true)
 
-      ended = end;
-      return fs.close(fd, function() {
-        cb(end);
+    //wait until we have got out of bed, then go back to bed.
+    //or if we are reading, wait till we read, then go back to bed.
+    else if(busy) {
+      _cb = cb
+      return closeNext = true
+    }
+
+    //first read was close, don't even get out of bed.
+    else if(!fd) {
+      return cb(true)
+    }
+
+    //go back to bed
+    else {
+      fs.close(fd, function(err) {
+        fd = null;
+        cb(err || true);
       });
     }
+  }
 
-    if (! fd) {
-      return open(cb);
+  return function(end, cb) {
+    if (end) {
+      ended = end;
+      close(cb);
+    }
+    // if we have already received the end notification, abort further
+    else if (ended) {
+      cb(ended)
     }
 
-    return readNext(cb);
+    else if (! fd) {
+      open(cb);
+    }
+
+    else
+      readNext(cb);
   };
 };
+
+
+
 

--- a/index.js
+++ b/index.js
@@ -2,7 +2,6 @@
 /* jshint node: true */
 'use strict';
 
-var pull = require('pull-core');
 var fs = require('fs');
 
 /**
@@ -17,7 +16,7 @@ var fs = require('fs');
   <<< examples/ipsum-chunks.js
 
 **/
-module.exports = pull.Source(function(filename, opts) {
+module.exports = function(filename, opts) {
   var mode = (opts || {}).mode || 0x1B6; // 0666
   var bufferSize = (opts || {}).bufferSize || 1024;
   var fd;
@@ -33,7 +32,7 @@ module.exports = pull.Source(function(filename, opts) {
       function(err, count, buffer) {
         // if we have received an end noticiation, just discard this data
         if (ended) {
-          return;
+          return cb(err || ended);
         }
 
         // if we encountered a read error pass it on
@@ -79,4 +78,5 @@ module.exports = pull.Source(function(filename, opts) {
 
     return readNext(cb);
   };
-});
+};
+

--- a/index.js
+++ b/index.js
@@ -34,8 +34,7 @@ module.exports = function(filename, opts) {
 
     fs.read(
       fd,
-      _buffer ||
-        new Buffer(toRead),
+      _buffer,
       0,
       toRead,
       start,
@@ -139,6 +138,7 @@ module.exports = function(filename, opts) {
   return source
 
 };
+
 
 
 

--- a/index.js
+++ b/index.js
@@ -18,11 +18,12 @@ var fs = require('fs');
 **/
 module.exports = function(filename, opts) {
   var mode = opts && opts.mode || 0x1B6; // 0666
-  var bufferSize = opts && opts.bufferSize || 1024;
+  var bufferSize = opts && opts.bufferSize || 1024*64;
   var start = opts && opts.start || 0
   var end = opts && opts.end || Number.MAX_SAFE_INTEGER
   var fd = opts && opts.fd
   var ended, closeNext, busy, _cb;
+  var _buffer = new Buffer(bufferSize)
 
   var flags = opts && opts.flags || 'r'
 
@@ -30,9 +31,11 @@ module.exports = function(filename, opts) {
     if(closeNext) return close(cb)
     var toRead = Math.min(end - start, bufferSize);
     busy = true
+
     fs.read(
       fd,
-      new Buffer(toRead),
+      _buffer ||
+        new Buffer(toRead),
       0,
       toRead,
       start,
@@ -62,6 +65,7 @@ module.exports = function(filename, opts) {
         }
       }
     );
+    _buffer = new Buffer(Math.min(end - start, bufferSize))
   }
 
   function open(cb) {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "author": "Damon Oehlman <damon.oehlman@gmail.com>",
   "license": "MIT",
   "devDependencies": {
+    "cont": "^1.0.3",
     "pull-stream": "^3.1.0",
     "tape": "^4.4.0"
   },

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "devDependencies": {
     "cont": "^1.0.3",
     "pull-stream": "^3.1.0",
+    "statistics": "^2.0.1",
     "tape": "^4.4.0"
   },
   "directories": {

--- a/package.json
+++ b/package.json
@@ -31,5 +31,8 @@
   "bugs": {
     "url": "https://github.com/DamonOehlman/pull-file/issues"
   },
-  "homepage": "https://github.com/DamonOehlman/pull-file"
+  "homepage": "https://github.com/DamonOehlman/pull-file",
+  "dependencies": {
+    "pull-utf8-decoder": "^1.0.2"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -14,9 +14,6 @@
   ],
   "author": "Damon Oehlman <damon.oehlman@gmail.com>",
   "license": "MIT",
-  "dependencies": {
-    "pull-core": "^1"
-  },
   "devDependencies": {
     "pull-stream": "^2",
     "tape": "^2"
@@ -34,3 +31,4 @@
   },
   "homepage": "https://github.com/DamonOehlman/pull-file"
 }
+

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
   "author": "Damon Oehlman <damon.oehlman@gmail.com>",
   "license": "MIT",
   "devDependencies": {
-    "pull-stream": "^2",
-    "tape": "^2"
+    "pull-stream": "^3.1.0",
+    "tape": "^4.4.0"
   },
   "directories": {
     "example": "examples",
@@ -31,4 +31,3 @@
   },
   "homepage": "https://github.com/DamonOehlman/pull-file"
 }
-

--- a/test/fd.js
+++ b/test/fd.js
@@ -1,0 +1,57 @@
+
+var tape = require('tape')
+var File = require('../')
+var pull = require('pull-stream')
+var fs = require('fs')
+
+var path = require('path')
+
+function asset(file) {
+  return path.join(__dirname, 'assets', file)
+}
+
+function all(stream, cb) {
+  pull(stream, pull.collect(function (err, ary) {
+    cb(err, Buffer.concat(ary))
+  }))
+}
+
+tape('can read a file with a provided fd', function (t) {
+
+  var fd = fs.openSync(asset('ipsum.txt'), 'r')
+
+  all(File(null, {fd: fd}), function (err, buf) {
+    if(err) throw err
+    t.ok(buf)
+    t.end()
+  })
+
+})
+
+
+tape('two files can read from one fd if autoClose is disabled', function (t) {
+  var fd = fs.openSync(asset('ipsum.txt'), 'r')
+
+  all(File(null, {fd: fd, autoClose: false}), function (err, buf1) {
+    if(err) throw err
+    t.ok(buf1)
+    all(File(null, {fd: fd, autoClose: false}), function (err, buf2) {
+      if(err) throw err
+      t.ok(buf2)
+      t.equal(buf1.toString(), buf2.toString())
+      fs.close(fd, function (err) {
+        if(err) throw err
+        t.end()
+      })
+    })
+  })
+
+})
+
+
+
+
+
+
+
+

--- a/test/largefile.js
+++ b/test/largefile.js
@@ -16,3 +16,23 @@ test('large file', function(t) {
     })
   );
 });
+
+
+test('large file as ascii strings', function(t) {
+  var expected = ['JTY', 'AU', '01', '0', '609', 'Australia/Sydney', '2012-02-29', ''];
+
+  t.plan(1);
+
+  pull(
+    file(path.resolve(__dirname, 'assets', 'AU.txt'), {encoding: 'ascii'}),
+    pull.through(function (str) {
+      t.equal(typeof str, 'string')
+    }),
+    pull.collect(function(err, items) {
+      var lastFields = items[items.length - 1].split(/\s+/);
+      t.deepEqual(lastFields.slice(-expected.length), expected, 'ok');
+    })
+  );
+});
+
+

--- a/test/partial.js
+++ b/test/partial.js
@@ -1,0 +1,69 @@
+
+var tape = require('tape')
+var path = require('path')
+var pull = require('pull-stream')
+var File = require('../')
+var cont = require('cont')
+var fs = require('fs')
+
+var crypto = require('crypto')
+
+function hash (data) {
+  return crypto.createHash('sha256').update(data).digest('hex')
+}
+
+function asset(file) {
+  return path.join(__dirname, 'assets', file)
+}
+
+var MB = 1024*1024
+
+tape('read files partially', function (t) {
+
+  function test (file, start, end) {
+    return function (cb) {
+      var opts = {start: start, end: end}
+      var expected
+      console.log(file)
+      var _expected = fs.readFileSync(file, opts)
+
+      console.log(
+          start || 0,
+          end || _expected.length
+      )
+      expected = _expected
+        .slice(
+          start || 0,
+          end || _expected.length
+        )
+
+      console.log('ELength', expected.length)
+
+      pull(
+        File(file, opts),
+        pull.collect(function (err, ary) {
+          var actual = Buffer.concat(ary)
+          t.equal(actual.length, expected.length)
+          t.equal(hash(actual), hash(expected))
+          cb()
+        })
+      )
+    }
+
+  }
+
+  cont.para([
+    test(asset('AU.txt'), 0, 10*MB),
+    test(asset('AU.txt'), 5*MB, 12*MB),
+    test(asset('AU.txt'), 5*MB, 6*MB),
+    test(asset('ipsum.txt')),
+    test(asset('test.txt'), 1, 4)
+  ])(function (err) {
+    t.end()
+  })
+
+})
+
+
+
+

--- a/test/terminate-read.js
+++ b/test/terminate-read.js
@@ -5,8 +5,10 @@ var file = require('..');
 var fs = require('fs')
 
 var ipsum = path.resolve(__dirname, 'assets', 'ipsum.txt')
+var au = path.resolve(__dirname, 'assets', 'AU.txt')
 
 test('can terminate read process', function(t) {
+
   var expected = [
     'Lorem ipsum dolor sit amet, consectetur ',
     'adipiscing elit. Quisque quis tortor eli',
@@ -64,7 +66,7 @@ test('can terminate file immediately (after open)', function (t) {
 
 test('can terminate file during a read', function (t) {
 
-  var source = file(ipsum)
+  var source = file(ipsum, {bufferSize: 1024})
   var sync1 = false, sync2 = false
   source(null, function (end, data) {
     t.equal(end, null)
@@ -72,12 +74,11 @@ test('can terminate file during a read', function (t) {
     source(null, function (end, data) {
       sync1 = true
       t.equal(end, true)
-      //t.equal(end, true)
       t.notOk(data, "data can't have been read")
     })
     source(true, function (end) {
       sync2 = true
-      t.equal(end, true)
+      t.equal(end, true, 'valid abort end')
       t.ok(sync1, 'read called back first')
       t.end()
     })
@@ -86,7 +87,6 @@ test('can terminate file during a read', function (t) {
   })
 
 })
-
 
 //usually the read succeeds before the close does,
 //but not always
@@ -128,4 +128,10 @@ test('after 10k times, cb order is always correct', function (t) {
   })()
 
 })
+
+
+
+
+
+
 

--- a/test/terminate-read.js
+++ b/test/terminate-read.js
@@ -11,13 +11,16 @@ test('can terminate read process', function(t) {
     'les. Suspendisse cursus, turpis eget dap'
   ];
 
-  t.plan(expected.length);
+//  t.plan(expected.length);
 
   pull(
     file(path.resolve(__dirname, 'assets', 'ipsum.txt'), { bufferSize: 40 }),
     pull.take(expected.length),
     pull.drain(function(data) {
       t.equal(data.toString(), expected.shift(), 'line ok in drain');
+    }, function (err) {
+      if(err) throw err
+      t.end()
     })
   );
 });

--- a/test/terminate-read.js
+++ b/test/terminate-read.js
@@ -2,6 +2,9 @@ var path = require('path');
 var test = require('tape');
 var pull = require('pull-stream');
 var file = require('..');
+var fs = require('fs')
+
+var ipsum = path.resolve(__dirname, 'assets', 'ipsum.txt')
 
 test('can terminate read process', function(t) {
   var expected = [
@@ -11,10 +14,8 @@ test('can terminate read process', function(t) {
     'les. Suspendisse cursus, turpis eget dap'
   ];
 
-//  t.plan(expected.length);
-
   pull(
-    file(path.resolve(__dirname, 'assets', 'ipsum.txt'), { bufferSize: 40 }),
+    file(ipsum, { bufferSize: 40 }),
     pull.take(expected.length),
     pull.drain(function(data) {
       t.equal(data.toString(), expected.shift(), 'line ok in drain');
@@ -24,3 +25,107 @@ test('can terminate read process', function(t) {
     })
   );
 });
+
+
+test('can terminate file immediately (before open)', function (t) {
+
+  var source = file(ipsum)
+  var sync = false
+  source(true, function (end) {
+    sync = true
+    t.equal(end, true)
+  })
+  t.ok(sync)
+  t.end()
+
+})
+
+
+test('can terminate file immediately (after open)', function (t) {
+
+  var source = file(ipsum)
+  var sync1 = false, sync2 = false
+  t.plan(6)
+  source(null, function (end, data) {
+    sync1 = true
+    t.equal(end, true, 'read aborted, end=true')
+    t.notOk(data, 'read aborted, data = null')
+  })
+  source(true, function (end) {
+    sync2 = true
+    t.ok(sync1, 'read cb was first')
+    t.equal(end, true)
+    t.end()
+  })
+  t.notOk(sync1)
+  t.notOk(sync2)
+
+})
+
+test('can terminate file during a read', function (t) {
+
+  var source = file(ipsum)
+  var sync1 = false, sync2 = false
+  source(null, function (end, data) {
+    t.equal(end, null)
+    t.ok(data)
+    source(null, function (end, data) {
+      sync1 = true
+      t.equal(end, true)
+      //t.equal(end, true)
+      t.notOk(data, "data can't have been read")
+    })
+    source(true, function (end) {
+      sync2 = true
+      t.equal(end, true)
+      t.ok(sync1, 'read called back first')
+      t.end()
+    })
+    t.notOk(sync1)
+    t.notOk(sync2)
+  })
+
+})
+
+
+//usually the read succeeds before the close does,
+//but not always
+
+test('after 10k times, cb order is always correct', function (t) {
+
+  var C = 0, R = 0, T = 0
+  ;(function next () {
+    T++
+
+    if(T > 10000) {
+      t.equal(R, 10000)
+      t.equal(C, 0)
+      t.equal(R+C, 10000)
+      console.log(C, R, T)
+      return t.end()
+    }
+
+    var fd = fs.openSync(__filename, 'r+', 0666)
+    var data, closed
+
+    //create a file stream with a fixed fd,
+    //configured to automatically close (as by default)
+    var source = file(null, {fd: fd})
+
+    //read.
+    source(null, function (err, _data) {
+      data = true
+      if(!closed) R++
+      if(data && closed) next()
+    })
+
+    //abort.
+    source(true, function (err) {
+      closed = true
+      if(!data) C ++
+      if(data && closed) next()
+    })
+  })()
+
+})
+


### PR DESCRIPTION
We can make this as fast (or faster) than node's read steam, but it ought to be a drop in replacement for 

``` js
var toPull = require('stream-to-pull-stream')
var fs = require('pull-stream')
toPull.source(fs.createReadStream(file, opts))
```

Don't merge this yet, a few more bits to come.
