### PR TITLE
Provide callback with closeNext

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,6 +60,7 @@ module.exports = function(filename, opts) {
           cb(null, buffer);
         } else {
           closeNext = true;
+          _cb = function () {}
           cb(null, buffer.slice(0, count));
         }
       }


### PR DESCRIPTION
I was getting an error about a missing callback:

```
TypeError: cb is not a function
    at /usr/local/src/ssb-blobs/node_modules/multiblob/node_modules/pull-file/index.js:111:9
    at FSReqWrap.oncomplete (fs.js:82:15)
```

This happened when I browse to http://localhost:7718/%25A%2FQL%2BT42fBU7E%2FyzQuwKZhSZ8ytd9mSMeoGRla9DDfY%3D.sha256/blob/master/helloworld.html while running [git-ssb-web](https://git-ssb.celehner.com/%25q5d5Du%2B9WkaSdjc8aJPZm%2BjMrqgo0tmfR%2BRcX5ZZ6H4%3D.sha256)

I added some `console.log(new Error().stack)` lines to reveal more of the call stack:

```
    at close (/usr/local/src/ssb-blobs/node_modules/multiblob/node_modules/pull-file/index.js:92:28)
    at /usr/local/src/ssb-blobs/node_modules/multiblob/node_modules/pull-file/index.js:78:9
    at FSReqWrap.oncomplete (fs.js:82:15)
```

```
    at open (/usr/local/src/ssb-blobs/node_modules/multiblob/node_modules/pull-file/index.js:73:21)
    at source (/usr/local/src/ssb-blobs/node_modules/multiblob/node_modules/pull-file/index.js:131:7)
    at next (/usr/local/src/pull-stream/sinks/drain.js:16:11)
    at sink (/usr/local/src/pull-stream/sinks/drain.js:37:9)
    at pull (/usr/local/src/pull-stream/pull.js:24:14)
    at Object.u.readObjectString (/usr/local/src/git-ssb-web/lib/util.js:115:3)
    at /usr/local/src/git-ssb-web/index.js:498:7
    at Array.<anonymous> (/usr/local/src/git-ssb-web/lib/util.js:34:5)
    at next (/usr/local/src/pull-cat/index.js:29:19)
    at Array.<anonymous> (/usr/local/src/pull-cat/index.js:44:7)
```

I'm not entirely sure what's going on, but I got the idea that when closeNext gets set, `_cb` is supposed to be set too. So adding this dummy callback function fixes the error that I was seeing.
