### PR TITLE
add support for {live: true} option, ala `tail -f`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 # pull-file
 
-This is a simple module which uses raw file reading methods available in
-the node `fs` module to read files on-demand.  It's a work in progress
-and feedback is welcome :)
-
+a pull-streaming file reader, build directly on the low level stream functions.
+by passing node's fs streams.
 
 [![NPM](https://nodei.co/npm/pull-file.png)](https://nodei.co/npm/pull-file/)
 
@@ -25,6 +23,12 @@ pull(
   })
 );
 ```
+## options
+
+this supports all the options that node's [fs.createReadStream](https://nodejs.org/dist/latest-v6.x/docs/api/fs.html#fs_fs_createreadstream_path_options) supports,
+and _also_ this supports a `live: true` property which will keep the stream open and wait for appends
+when it gets to the end.
+
 
 ## License(s)
 
@@ -50,3 +54,4 @@ IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
 CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
 TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+

--- a/index.js
+++ b/index.js
@@ -22,19 +22,20 @@ module.exports = function(filename, opts) {
   var start = opts && opts.start || 0
   var end = opts && opts.end || Number.MAX_SAFE_INTEGER
   var fd = opts && opts.fd
-  var ended, closeNext, busy, _cb;
+
+  var ended, closeNext, busy;
   var _buffer = new Buffer(bufferSize)
-  var live = !!opts.live
-  var _cb
+  var live = opts && !!opts.live
+  var liveCb, closeCb
   var watcher
   if(live) {
     watcher = fs.watch(filename, {
       persistent: opts.persistent !== false,
     },
-    function (event, filename, stat) {
-      if(_cb) {
-        var cb = _cb
-        _cb = null
+    function (event) {
+      if(liveCb && event === 'change') {
+        var cb = liveCb
+        liveCb = null
         closeNext = false
         readNext(cb)
       }
@@ -46,11 +47,12 @@ module.exports = function(filename, opts) {
 
   function readNext(cb) {
     if(closeNext) {
-      if(!live) return close(cb)
-      else return _cb = cb
+      if(!live) close(cb);
+      else liveCb = cb;
+      return
     }
     var toRead = Math.min(end - start, bufferSize);
-    busy = true
+    busy = true;
 
     fs.read(
       fd,
@@ -59,12 +61,12 @@ module.exports = function(filename, opts) {
       toRead,
       start,
       function(err, count, buffer) {
-        busy = false
+        busy = false;
         start += count;
         // if we have received an end noticiation, just discard this data
         if(closeNext && !live) {
-          close(_cb)
-          return cb(closeNext)
+          close(closeCb);
+          return cb(closeNext);
         }
 
         if (ended) {
@@ -78,6 +80,8 @@ module.exports = function(filename, opts) {
 
         if(count === buffer.length) {
           cb(null, buffer);
+        } else if(count === 0 && live) {
+          liveCb = cb; closeNext = true
         } else {
           closeNext = true;
           cb(null, buffer.slice(0, count));
@@ -88,15 +92,15 @@ module.exports = function(filename, opts) {
   }
 
   function open(cb) {
-    busy = true
+    busy = true;
     fs.open(filename, flags, mode, function(err, descriptor) {
       // save the file descriptor
       fd = descriptor;
 
       busy = false
       if(closeNext) {
-        close(_cb)
-        return cb(closeNext)
+        close(closeCb);
+        return cb(closeNext);
       }
 
       if (err) {
@@ -109,6 +113,7 @@ module.exports = function(filename, opts) {
   }
 
   function close (cb) {
+    if(!cb) throw new Error('close must have cb')
     if(watcher) watcher.close()
     //if auto close is disabled, then user manages fd.
     if(opts && opts.autoClose === false) return cb(true)
@@ -116,7 +121,7 @@ module.exports = function(filename, opts) {
     //wait until we have got out of bed, then go back to bed.
     //or if we are reading, wait till we read, then go back to bed.
     else if(busy) {
-      _cb = cb
+      closeCb = cb
       return closeNext = true
     }
 
@@ -129,7 +134,6 @@ module.exports = function(filename, opts) {
     else {
       fs.close(fd, function(err) {
         fd = null;
-        if(_cb) _cb(err || true)
         cb(err || true);
       });
     }
@@ -138,12 +142,15 @@ module.exports = function(filename, opts) {
   function source (end, cb) {
     if (end) {
       ended = end;
-      live = false
+      live = false;
+      if(liveCb) {
+        liveCb(end || true);
+      }
       close(cb);
     }
     // if we have already received the end notification, abort further
     else if (ended) {
-      cb(ended)
+      cb(ended);
     }
 
     else if (! fd) {

--- a/index.js
+++ b/index.js
@@ -26,9 +26,9 @@ module.exports = function(filename, opts) {
   var _buffer = new Buffer(bufferSize)
   var live = !!opts.live
   var _cb
-
+  var watcher
   if(live) {
-    fs.watch(filename, {
+    watcher = fs.watch(filename, {
       persistent: opts.persistent !== false,
     },
     function (event, filename, stat) {
@@ -109,6 +109,7 @@ module.exports = function(filename, opts) {
   }
 
   function close (cb) {
+    if(watcher) watcher.close()
     //if auto close is disabled, then user manages fd.
     if(opts && opts.autoClose === false) return cb(true)
 
@@ -128,6 +129,7 @@ module.exports = function(filename, opts) {
     else {
       fs.close(fd, function(err) {
         fd = null;
+        if(_cb) _cb(err || true)
         cb(err || true);
       });
     }
@@ -136,6 +138,7 @@ module.exports = function(filename, opts) {
   function source (end, cb) {
     if (end) {
       ended = end;
+      live = false
       close(cb);
     }
     // if we have already received the end notification, abort further

--- a/test/append.js
+++ b/test/append.js
@@ -12,24 +12,37 @@ tape('append to a file', function (t) {
   var n = 10, r = 0, ended = false
   ;(function next () {
     --n
-    fs.appendFile(filename, Date.now() +'\n', function (e) {
-      if(n) setTimeout(next, 20).unref()
-      else { ended = true; drain.abort() }
+    fs.appendFile(filename, Date.now() +'\n', function (err) {
+      if(err) throw err
+
+      if(n) setTimeout(next, 20)
+      else { ended = true; }
     })
   })()
 
-  var drain = pull.drain(function (chunk) {
-    r ++
-    t.notEqual(chunk.length, 0)
-  }, function (err) {
-    t.equal(n, 0, 'writes')
-    t.equal(r, 10, 'reads')
-    t.end()
-  })
-
-
-  pull(File(filename, {live: true}), drain)
+  pull(
+    File(filename, {live: true}),
+    pull.through(function (chunk) {
+      r ++
+      t.notEqual(chunk.length, 0)
+    }),
+    pull.take(10),
+    pull.drain(null, function (err) {
+      if(err) throw err
+      t.equal(n, 0, 'writes')
+      t.equal(r, 10, 'reads')
+      t.end()
+    })
+  )
 })
+
+
+
+
+
+
+
+
 
 
 

--- a/test/append.js
+++ b/test/append.js
@@ -1,0 +1,34 @@
+
+var pull = require('pull-stream')
+var fs = require('fs')
+var File = require('../')
+
+var tape = require('tape')
+
+tape('append to a file', function (t) {
+
+  var filename = '/tmp/test_pull-file_append'+Date.now()
+
+  ;(function next () {
+    fs.appendFile(filename, new Date() +'\n', function (e) {
+      setTimeout(next, 1000)
+    })
+    
+  })()
+
+  pull(
+    File(filename, {live: true}),
+    pull.drain(function (chunk) {
+      console.log('chunk', chunk.toString())
+    }, function (err) {
+      if(err) throw err
+      t.fail('stream ended')
+
+    })
+  )
+
+
+})
+
+
+

--- a/test/terminate-read.js
+++ b/test/terminate-read.js
@@ -28,7 +28,6 @@ test('can terminate read process', function(t) {
   );
 });
 
-
 test('can terminate file immediately (before open)', function (t) {
 
   var source = file(ipsum)
@@ -42,18 +41,19 @@ test('can terminate file immediately (before open)', function (t) {
 
 })
 
-
 test('can terminate file immediately (after open)', function (t) {
 
   var source = file(ipsum)
   var sync1 = false, sync2 = false
   t.plan(6)
   source(null, function (end, data) {
+    if(sync1) throw new Error('read1 called twice')
     sync1 = true
     t.equal(end, true, 'read aborted, end=true')
     t.notOk(data, 'read aborted, data = null')
   })
   source(true, function (end) {
+    if(sync2) throw new Error('read2 called twice')
     sync2 = true
     t.ok(sync1, 'read cb was first')
     t.equal(end, true)
@@ -128,6 +128,9 @@ test('after 10k times, cb order is always correct', function (t) {
   })()
 
 })
+
+
+
 
 
 


### PR DESCRIPTION
this adds support for live streams. this means it is now possible to stream your, say, log file, and the the latest changes. getting the abort state correct is important (though tricky) there is a test too.

I've called the property `live` since that the same as all my level modules, etc
