### PR TITLE
fix: lock source to ensure no double reads happen

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   },
   "homepage": "https://github.com/DamonOehlman/pull-file",
   "dependencies": {
+    "lock": "^0.1.3",
     "pull-utf8-decoder": "^1.0.2"
   }
 }

--- a/test/largefile.js
+++ b/test/largefile.js
@@ -43,8 +43,43 @@ test('large file as ascii strings', function(t) {
   );
 });
 
+test('large file fast reads', function(t) {
+  var big = crypto.pseudoRandomBytes(10*1024*1024)
+  fs.writeFileSync(tmpfile, big)
 
+  var read = file(tmpfile, {bufferSize: 1024 * 1024})
+  var items = []
 
+  read(null, checkRead)
+  read(null, checkRead)
+  read(null, checkRead)
+  read(null, checkRead)
+  read(null, checkRead)
 
+  setTimeout(function () {
+    read(null, checkRead)
+    read(null, checkRead)
+    read(null, checkRead)
+    read(null, checkRead)
+    read(null, checkRead)
+    read(null, function (err, data) {
+      t.equal(err, true)
+      t.equal(data, undefined)
+      next()
+    })
+  }, 10)
 
+  function checkRead (err, data) {
+    t.equal(data.length, 1024 * 1024)
+    items.push(data)
+    next()
+  }
 
+  var i = 0
+  function next () {
+    if (++i === 11) {
+      t.equal(hash(big), hash(Buffer.concat(items)))
+      t.end()
+    }
+  }
+})


### PR DESCRIPTION
When the source is read very fast while the file descriptor is still
being opened it can come to double reads of chunks of the file. This
introduces a lock to avoid this issue.
